### PR TITLE
Refactor entities types

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,17 +78,20 @@ const configs = [
       {
         file: 'dist/grapholscape.min.js',
         format: 'iife',
+        inlineDynamicImports : true,
         name,
         sourcemap: false
       },
       {
         file: 'dist/grapholscape.esm.min.js',
         format: 'es',
+        inlineDynamicImports : true,
         sourcemap: false
       },
       {
         file: 'demo/js/grapholscape.js',
         format: 'iife',
+        inlineDynamicImports : true,
         name,
         sourcemap: false
       },
@@ -107,6 +110,7 @@ const configs = [
     input,
     output: {
       file: 'dist/grapholscape.esm.js',
+      inlineDynamicImports : true,
       format: 'es',
     },
     plugins: [

--- a/src/core/displayedNamesManager.ts
+++ b/src/core/displayedNamesManager.ts
@@ -65,11 +65,11 @@ export default class DisplayedNamesManager {
         let grapholElement: GrapholElement | undefined
 
         if (renderState === RendererStatesEnum.INCREMENTAL) {
-          // incremental diagram is not in the ontology, must take it from rendererStateData in renderer
+          // incremental diagram is not in the ontology, must take it from inremental controller
           grapholElement = this._grapholscape.incremental?.diagram?.representation
-            ?.grapholElements.get(entityOccurrence.elementId)
+            ?.grapholElements.get(entityOccurrence.id)
         } else {
-          grapholElement = this._grapholscape.ontology.getGrapholElement(entityOccurrence.elementId, entityOccurrence.diagramId, renderState)
+          grapholElement = this._grapholscape.ontology.getGrapholElement(entityOccurrence.id, entityOccurrence.diagramId, renderState)
         }
 
         if (!grapholElement) return

--- a/src/incremental/diagram-builder.ts
+++ b/src/incremental/diagram-builder.ts
@@ -144,6 +144,7 @@ export default class DiagramBuilder {
     instanceNode.labelYpos = 0
 
     this.diagram.addElement(instanceNode, classInstanceEntity)
+    classInstanceEntity.addOccurrence(instanceNode, RendererStatesEnum.INCREMENTAL)
     return instanceNode
   }
 

--- a/src/incremental/diagram-builder.ts
+++ b/src/incremental/diagram-builder.ts
@@ -1,4 +1,4 @@
-import { Position } from "cytoscape";
+import cytoscape, { Position } from "cytoscape";
 import { EntityNameType } from "../config";
 import { ClassInstanceEntity, GrapholEdge, GrapholEntity, GrapholNode, GrapholTypesEnum, IncrementalDiagram, isGrapholNode, RendererStatesEnum, Shape } from "../model";
 
@@ -7,51 +7,52 @@ export default class DiagramBuilder {
 
   constructor(public diagram: IncrementalDiagram) { }
 
-  addEntity(objectProperty: GrapholEntity, sourceEntity: GrapholEntity, targetEntity: GrapholEntity): void
-  addEntity(grapholEntity: GrapholEntity): void
-  addEntity(grapholEntity: GrapholEntity, sourceEntity?: GrapholEntity, targetEntity?: GrapholEntity): void {
-    switch (grapholEntity.type) {
-      case GrapholTypesEnum.DATA_PROPERTY:
-        if (sourceEntity)
-          this.addDataProperty(grapholEntity, sourceEntity)
-        break
+  // addEntity(objectProperty: GrapholEntity, sourceEntity: GrapholEntity, targetEntity: GrapholEntity): void
+  // addEntity(grapholEntity: GrapholEntity): void
+  // addEntity(grapholEntity: GrapholEntity, sourceEntity?: GrapholEntity, targetEntity?: GrapholEntity): void {
+  //   switch (grapholEntity.type) {
+  //     case GrapholTypesEnum.DATA_PROPERTY:
+  //       if (sourceEntity)
+  //         this.addDataProperty(grapholEntity, sourceEntity)
+  //       break
 
-      case GrapholTypesEnum.OBJECT_PROPERTY:
-        if (sourceEntity && targetEntity)
-          this.addObjectProperty(grapholEntity, sourceEntity, targetEntity)
-        break
+  //     case GrapholTypesEnum.OBJECT_PROPERTY:
+  //       if (sourceEntity && targetEntity)
+  //         this.addObjectProperty(grapholEntity, sourceEntity, targetEntity)
+  //       break
 
-      case GrapholTypesEnum.CLASS:
-        if (!this.diagram.containsEntity(grapholEntity))
-          this.addClass(grapholEntity)
-        break
+  //     case GrapholTypesEnum.CLASS:
+  //       if (!this.diagram.containsEntity(grapholEntity))
+  //         this.addClass(grapholEntity)
+  //       break
 
-      case GrapholTypesEnum.CLASS_INSTANCE:
-        if (!this.diagram.containsEntity(grapholEntity))
-          this.addClassInstance(grapholEntity as ClassInstanceEntity)
+  //     case GrapholTypesEnum.CLASS_INSTANCE:
+  //       if (!this.diagram.containsEntity(grapholEntity))
+  //         this.addClassInstance(grapholEntity as ClassInstanceEntity)
 
-    }
-  }
+  //   }
+  // }
 
   addClass(classEntity: GrapholEntity, position?: Position) {
     if (this.diagramRepresentation?.grapholElements.get(classEntity.iri.fullIri))
       return
 
-    const classNode = new GrapholNode(classEntity.iri.fullIri, GrapholTypesEnum.CLASS)
+    const classNode = new GrapholNode(`${classEntity.iri.fullIri}-${GrapholTypesEnum.CLASS}`, GrapholTypesEnum.CLASS)
     classNode.iri = classEntity.iri.fullIri
     classNode.displayedName = classEntity.getDisplayedName(EntityNameType.LABEL)
     classNode.height = classNode.width = 80
     classNode.position = position || { x: 0, y: 0 }
     classNode.originalId = classEntity.getEntityOriginalNodeId()
+    classNode.diagramId = this.diagram.id
 
-    classEntity.addOccurrence(classNode.id, this.diagram.id, RendererStatesEnum.INCREMENTAL)
+    classEntity.addOccurrence(classNode, RendererStatesEnum.INCREMENTAL)
 
     this.diagram.addElement(classNode, classEntity)
   }
 
   addDataProperty(dataPropertyEntity: GrapholEntity, ownerEntity: GrapholEntity) {
 
-    const dataPropertyNode = new GrapholNode(dataPropertyEntity.iri.fullIri, GrapholTypesEnum.DATA_PROPERTY)
+    const dataPropertyNode = new GrapholNode(`${dataPropertyEntity.iri.fullIri}-${GrapholTypesEnum.DATA_PROPERTY}`, GrapholTypesEnum.DATA_PROPERTY)
     const ownerEntityNode = this.diagramRepresentation?.grapholElements.get(ownerEntity.iri.fullIri)
     if (!dataPropertyNode || !ownerEntityNode) return
 
@@ -70,13 +71,22 @@ export default class DiagramBuilder {
     this.diagram.addElement(dataPropertyEdge)
   }
 
-  addObjectProperty(objectPropertyEntity: GrapholEntity, sourceEntity: GrapholEntity, targetEntity: GrapholEntity) {
+  addObjectProperty(
+    objectPropertyEntity: GrapholEntity,
+    sourceEntity: GrapholEntity,
+    targetEntity: GrapholEntity,
+    nodesType: GrapholTypesEnum
+  ) {
 
-    if (!this.diagramRepresentation) return
+    if (!this.diagramRepresentation ||
+      !sourceEntity.is(nodesType) ||
+      !targetEntity.is(nodesType)
+    ) return
 
     // if both object property and range class are already present, do not add them again
-    const sourceNode = this.diagramRepresentation.cy.$id(sourceEntity.iri.fullIri)
-    const targetNode = this.diagramRepresentation.cy.$id(targetEntity.iri.fullIri)
+    const sourceNode = this.getEntityCyRepr(sourceEntity, nodesType)
+    const targetNode = this.getEntityCyRepr(targetEntity, nodesType)
+
     if (sourceNode.nonempty() && targetNode.nonempty()) {
       /**
        * If the set of edges between reference node and the connected class
@@ -91,30 +101,31 @@ export default class DiagramBuilder {
     }
 
     if (sourceNode.empty())
-      sourceEntity.is(GrapholTypesEnum.CLASS_INSTANCE) ? this.addClassInstance(sourceEntity as ClassInstanceEntity) : this.addEntity(sourceEntity)
+      nodesType === GrapholTypesEnum.CLASS_INSTANCE ? this.addClassInstance(sourceEntity as ClassInstanceEntity) : this.addClass(sourceEntity)
 
     if (targetNode.empty())
-      targetEntity.is(GrapholTypesEnum.CLASS_INSTANCE) ? this.addClassInstance(targetEntity as ClassInstanceEntity) : this.addEntity(targetEntity)
+      nodesType === GrapholTypesEnum.CLASS_INSTANCE ? this.addClassInstance(targetEntity as ClassInstanceEntity) : this.addClass(targetEntity)
 
     //const connectedClassIri = connectedClassEntity.iri.fullIri
     const objectPropertyEdge = new GrapholEdge(`${sourceEntity.iri.prefixed}-${objectPropertyEntity.iri.prefixed}-${targetEntity.iri.prefixed}`, GrapholTypesEnum.OBJECT_PROPERTY)
     objectPropertyEdge.displayedName = objectPropertyEntity.getDisplayedName(EntityNameType.LABEL)
-    objectPropertyEdge.sourceId = sourceEntity.iri.fullIri
-    objectPropertyEdge.targetId = targetEntity.iri.fullIri
+    objectPropertyEdge.sourceId = `${sourceEntity.iri.fullIri}-${nodesType}`
+    objectPropertyEdge.targetId = `${targetEntity.iri.fullIri}-${nodesType}`
     objectPropertyEdge.originalId = objectPropertyEntity.getEntityOriginalNodeId()
+    objectPropertyEdge.diagramId = this.diagram.id
 
-    objectPropertyEntity.addOccurrence(objectPropertyEdge.id, this.diagram.id, RendererStatesEnum.INCREMENTAL)
+    objectPropertyEntity.addOccurrence(objectPropertyEdge, RendererStatesEnum.INCREMENTAL)
     this.diagram.addElement(objectPropertyEdge, objectPropertyEntity)
   }
 
   addClassInstance(classInstanceEntity: ClassInstanceEntity, position?: Position) {
-    const instanceNode = new GrapholNode(classInstanceEntity.iri.fullIri, GrapholTypesEnum.CLASS_INSTANCE)
+    const instanceNode = new GrapholNode(`${classInstanceEntity.iri.fullIri}-${GrapholTypesEnum.CLASS_INSTANCE}`, GrapholTypesEnum.CLASS_INSTANCE)
 
     if (!position) {
       // check if parent class is present in diagram
       for (let parentClassIri of classInstanceEntity.parentClassIris) {
         if (this.diagramRepresentation?.containsEntity(parentClassIri)) {
-          instanceNode.position = this.diagram.representation?.cy.$id(parentClassIri.fullIri).position() || { x: 0, y: 0 }
+          instanceNode.position = this.diagram.representation?.cy.$id(`${parentClassIri.fullIri}-${GrapholTypesEnum.CLASS}`).position() || { x: 0, y: 0 }
           break
         }
       }
@@ -154,6 +165,10 @@ export default class DiagramBuilder {
       this.diagram.addElement(instanceEdge)
     }
 
+  }
+
+  private getEntityCyRepr(entity: GrapholEntity, type: GrapholTypesEnum) {
+    return this.diagramRepresentation?.cy.$id(`${entity.iri.fullIri}-${type}`) || cytoscape().collection()
   }
 
   private get diagramRepresentation() {

--- a/src/incremental/index.ts
+++ b/src/incremental/index.ts
@@ -39,7 +39,7 @@ export function initIncremental(grapholscape: Grapholscape) {
       x: Math.random() * 200,
       y: Math.random() * 200
     }
-    incrementalController.addEntity(classIri, true, randomPos)
+    incrementalController.addClass(classIri, true, randomPos)
     grapholscape.selectElement(classIri)
     IncrementalUI.moveUpLeft(entitySelector)
     entitySelector.closePanel()

--- a/src/incremental/neighbourhood-finder.ts
+++ b/src/incremental/neighbourhood-finder.ts
@@ -139,7 +139,7 @@ export default class NeighbourhoodFinder {
 
         if (diagram) {
           const inclusionEdges = diagram.representations.get(RendererStatesEnum.FLOATY)
-            ?.cy.$id(classOccurrence.elementId)
+            ?.cy.$id(classOccurrence.id)
             .edgesWith(`[ type = "${GrapholTypesEnum.CLASS}" ]`) // take all edges going/coming to/from other classes
             .filter(edge => edge.data().type === type) // take only inclusions/equivalence edges
 

--- a/src/incremental/ui/class-instance-details/class-instance-details.ts
+++ b/src/incremental/ui/class-instance-details/class-instance-details.ts
@@ -42,7 +42,7 @@ export default class GscapeClassInstanceDetails extends BaseMixin(LitElement) {
                   <gscape-entity-list-item
                     displayedname=${parentClass.displayedName}
                     iri=${parentClass.value.iri.fullIri}
-                    type=${parentClass.value.type}
+                    .types=${parentClass.value.types}
                     @click=${this.handleEntityClick}
                   >
                   </gscape-entity-list-item>
@@ -66,7 +66,7 @@ export default class GscapeClassInstanceDetails extends BaseMixin(LitElement) {
                   <gscape-entity-list-item
                     displayedname=${dataProperty.displayedName}
                     iri=${dataProperty.value.iri.fullIri}
-                    type=${dataProperty.value.type}
+                    .types=${dataProperty.value.types}
                   >
                     ${this.canShowDataPropertiesValues && values
                       ? html`

--- a/src/incremental/ui/commands-widget/index.ts
+++ b/src/incremental/ui/commands-widget/index.ts
@@ -167,7 +167,11 @@ export function CommandsWidgetFactory(ic: IncrementalController) {
       IncrementalCommands.remove(() => {
         if (entity.is(GrapholTypesEnum.OBJECT_PROPERTY)) {
           ic.diagram.removeElement(event.target.id())
-          entity.removeOccurrence(event.target.id(), ic.diagram.id, RendererStatesEnum.INCREMENTAL)
+          const grapholOccurrence = ic.diagram.representation?.grapholElements.get(event.target.id())
+          if (grapholOccurrence) {
+            entity.removeOccurrence(grapholOccurrence, RendererStatesEnum.INCREMENTAL)
+          }
+
           ic.lifecycle.trigger(IncrementalEvent.DiagramUpdated)
         } else {
           ic.removeEntity(entity.iri.fullIri)
@@ -193,7 +197,7 @@ function showParentClass(incrementalController: IncrementalController, instanceE
   const parentClassIris = instanceEntity.parentClassIris
   incrementalController.performActionWithBlockedGraph(() => {
     parentClassIris?.forEach(parentClassIri => {
-      incrementalController.addEntity(parentClassIri.fullIri, false)
+      incrementalController.addClass(parentClassIri.fullIri, false)
       incrementalController.addEdge(instanceEntity.iri.fullIri,
         parentClassIri.fullIri,
         GrapholTypesEnum.INSTANCE_OF

--- a/src/incremental/ui/commands-widget/index.ts
+++ b/src/incremental/ui/commands-widget/index.ts
@@ -198,8 +198,9 @@ function showParentClass(incrementalController: IncrementalController, instanceE
   incrementalController.performActionWithBlockedGraph(() => {
     parentClassIris?.forEach(parentClassIri => {
       incrementalController.addClass(parentClassIri.fullIri, false)
-      incrementalController.addEdge(instanceEntity.iri.fullIri,
-        parentClassIri.fullIri,
+      incrementalController.addEdge(
+        `${instanceEntity.iri.fullIri}-${GrapholTypesEnum.CLASS_INSTANCE}`,
+        `${parentClassIri.fullIri}-${GrapholTypesEnum.CLASS}`,
         GrapholTypesEnum.INSTANCE_OF
       )
     })

--- a/src/incremental/ui/instances-explorer/index.ts
+++ b/src/incremental/ui/instances-explorer/index.ts
@@ -83,7 +83,7 @@ export function InstanceExplorerFactory(incrementalController: IncrementalContro
     instancesExplorer.areInstancesLoading = true
 
     if (instancesExplorer.referenceEntity) {
-      if (instancesExplorer.referenceEntity.value.type === GrapholTypesEnum.CLASS) {
+      if (instancesExplorer.referenceEntity.value.types.has(GrapholTypesEnum.CLASS)) {
         instancesExplorer.requestId = await incrementalController.endpointController?.requestInstancesForClass(
           instancesExplorer.referenceEntity?.value.iri.fullIri,
           e.detail.shouldAskForLabels,
@@ -94,7 +94,7 @@ export function InstanceExplorerFactory(incrementalController: IncrementalContro
         )
       }
 
-      else if (instancesExplorer.referenceEntity.value.type === GrapholTypesEnum.CLASS_INSTANCE && instancesExplorer.referencePropertyEntity) {
+      else if (instancesExplorer.referenceEntity.value.types.has(GrapholTypesEnum.CLASS_INSTANCE) && instancesExplorer.referencePropertyEntity) {
         // if (e.detail.filterByType) {
         //   instancesExplorer.propertiesFilterList = (await incrementalController.getDataPropertiesByClasses([e.detail.filterByType]))
         //     .map(dp => getEntityViewDataIncremental(dp, incrementalController))

--- a/src/incremental/ui/instances-explorer/index.ts
+++ b/src/incremental/ui/instances-explorer/index.ts
@@ -38,7 +38,11 @@ export function InstanceExplorerFactory(incrementalController: IncrementalContro
 
     addedInstanceEntity = incrementalController.addInstance(e.detail.instance, e.detail.parentClassIris)
     addedInstanceEntity.parentClassIris.forEach(parentClassIri => {
-      incrementalController.addEdge(e.detail.instance.iri, parentClassIri.fullIri, GrapholTypesEnum.INSTANCE_OF)
+      incrementalController.addEdge(
+        `${e.detail.instance.iri}-${GrapholTypesEnum.CLASS_INSTANCE}`,
+        `${parentClassIri.fullIri}-${GrapholTypesEnum.CLASS}`,
+        GrapholTypesEnum.INSTANCE_OF
+      )
     })
 
     if (e.detail.instance.connectedInstance && e.detail.filterByProperty) {

--- a/src/incremental/ui/instances-explorer/instance-explorer.ts
+++ b/src/incremental/ui/instances-explorer/instance-explorer.ts
@@ -18,6 +18,7 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
   propertiesFilterList: EntityViewDataUnfolding[] = []
   classTypeFilterList?: EntityViewDataUnfolding[]
   referenceEntity?: EntityViewData
+  referenceEntityType?: GrapholTypesEnum
   referencePropertyEntity?: EntityViewData
   isPropertyDirect: boolean = true
   requestId?:string
@@ -125,7 +126,7 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
           <gscape-entity-list-item
             displayedname=${this.referenceEntity?.displayedName}
             iri=${this.referenceEntity?.value.iri.fullIri}
-            type=${this.referenceEntity?.value.type}
+            .types=${this.referenceEntity?.value.types}
           ></gscape-entity-list-item>
 
           ${this.referencePropertyEntity
@@ -133,7 +134,7 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
               <gscape-entity-list-item
                 displayedname=${this.referencePropertyEntity?.displayedName}
                 iri=${this.referencePropertyEntity?.value.iri.fullIri}
-                type=${this.referencePropertyEntity?.value.type}
+                .types=${this.referencePropertyEntity?.value.types}
               >
                 ${!this.isPropertyDirect
                   ? html`
@@ -158,7 +159,7 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
                     return {
                       id: entity.entityViewData.value.iri.fullIri,
                       text: entity.entityViewData.displayedName,
-                      leadingIcon: entityIcons[entity.entityViewData.value.type],
+                      leadingIcon: entityIcons[Array.from(entity.entityViewData.value.types)[0]],
                       disabled: !entity.hasUnfolding
                     }
                   })}
@@ -172,7 +173,7 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
                 <gscape-entity-list-item
                   displayedname=${this.classTypeFilterList[0].entityViewData.displayedName}
                   iri=${this.classTypeFilterList[0].entityViewData.value.iri.fullIri}
-                  type=${this.classTypeFilterList[0].entityViewData.value.type}
+                  .types=${this.classTypeFilterList[0].entityViewData.value.types}
                 ></gscape-entity-list-item>
               `
             : null
@@ -200,7 +201,7 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
                   return {
                     id: entity.entityViewData.value.iri.fullIri,
                     text: entity.entityViewData.displayedName,
-                    leadingIcon: entityIcons[entity.entityViewData.value.type],
+                    leadingIcon: entityIcons[Array.from(entity.entityViewData.value.types)[0]],
                     disabled: !entity.hasUnfolding
                   }
                 }))}
@@ -314,9 +315,9 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
         })
   
         if (property) {
-          event.detail.propertyType = property.entityViewData.value.type as GrapholTypesEnum.DATA_PROPERTY | GrapholTypesEnum.OBJECT_PROPERTY
+          event.detail.propertyType = Array.from(property.entityViewData.value.types)[0] as GrapholTypesEnum.DATA_PROPERTY | GrapholTypesEnum.OBJECT_PROPERTY
   
-          if (property.entityViewData.value.type === GrapholTypesEnum.OBJECT_PROPERTY) {
+          if (property.entityViewData.value.types.has(GrapholTypesEnum.OBJECT_PROPERTY)) {
             event.detail.direct = (property as ViewObjectPropertyUnfolding).direct
           }
         }
@@ -378,9 +379,9 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
       if (instance) {
         let parentClassIris: string[] | string
   
-        if (this.referenceEntity?.value.type === GrapholTypesEnum.CLASS) { // if class, take class iri as parent
+        if (this.referenceEntity?.value.types.has(GrapholTypesEnum.CLASS)) { // if class, take class iri as parent
           parentClassIris = this.referenceEntity?.value.iri.fullIri
-        } else if (this.referenceEntity?.value.type === GrapholTypesEnum.CLASS_INSTANCE) { // otherwise check selected filter type
+        } else if (this.referenceEntity?.value.types.has(GrapholTypesEnum.CLASS_INSTANCE)) { // otherwise check selected filter type
 
           if (this.classTypeFilterList?.length === 1) { 
             parentClassIris = this.classTypeFilterList[0].entityViewData.value.iri.fullIri // if only one type, take it as parent class

--- a/src/incremental/ui/instances-explorer/instance-explorer.ts
+++ b/src/incremental/ui/instances-explorer/instance-explorer.ts
@@ -247,7 +247,7 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
                 <gscape-entity-list-item
                   displayedname=${displayedName}
                   iri=${instance.connectedInstance ? `${instance.iri}-${instance.connectedInstance.iri}` : instance.iri}
-                  type=${GrapholTypesEnum.CLASS_INSTANCE}
+                  .types=${new Set([GrapholTypesEnum.CLASS_INSTANCE])}
                 >
                   <div slot="trailing-element" class="hover-btn">
                     <gscape-button
@@ -449,6 +449,7 @@ export default class GscapeInstanceExplorer extends ContextualWidgetMixin(BaseMi
     this.classTypeFilterList = []
     this.classTypeFilterSelect?.clear()
     this.referenceEntity = undefined
+    this.referenceEntityType = undefined
     this.referencePropertyEntity = undefined
     this.popperRef = undefined
     this.shouldAskForLabels = undefined

--- a/src/incremental/ui/navigation-menu/index.ts
+++ b/src/incremental/ui/navigation-menu/index.ts
@@ -47,6 +47,7 @@ export function NavigationMenuFactory(incrementalController: IncrementalControll
         instancesExplorer.clear()
         instancesExplorer.areInstancesLoading = true
         instancesExplorer.referenceEntity = navigationMenu.referenceEntity
+        instancesExplorer.referenceEntityType = navigationMenu.referenceEntityType
         instancesExplorer.referencePropertyEntity = grapholEntityToEntityViewData(objectPropertyEntity, incrementalController.grapholscape)
         instancesExplorer.isPropertyDirect = e.detail.direct
 

--- a/src/incremental/ui/navigation-menu/navigation-menu.ts
+++ b/src/incremental/ui/navigation-menu/navigation-menu.ts
@@ -18,6 +18,8 @@ export default class GscapeNavigationMenu extends ContextualWidgetMixin(BaseMixi
   canShowObjectPropertiesRanges = true
   /** @internal */
   referenceEntity?: EntityViewData
+  /** @internal */
+  referenceEntityType?: GrapholTypesEnum
 
   static properties: PropertyDeclarations = {
     objectProperties: { type: Object },
@@ -49,7 +51,7 @@ export default class GscapeNavigationMenu extends ContextualWidgetMixin(BaseMixi
         <gscape-entity-list-item
           displayedname=${this.referenceEntity?.displayedName}
           iri=${this.referenceEntity?.value.iri.fullIri}
-          type=${this.referenceEntity?.value.type}
+          .types=${this.referenceEntity?.value.types}
         ></gscape-entity-list-item>
       </div>
 
@@ -65,7 +67,7 @@ export default class GscapeNavigationMenu extends ContextualWidgetMixin(BaseMixi
                   <gscape-entity-list-item
                     displayedname=${objectProperty.entityViewData.displayedName}
                     iri=${objectProperty.entityViewData.value.iri.fullIri}
-                    type=${objectProperty.entityViewData.value.type}
+                    .types=${objectProperty.entityViewData.value.types}
                     ?actionable=${!this.canShowObjectPropertiesRanges}
                     ?asaccordion=${this.canShowObjectPropertiesRanges}
                     ?disabled=${disabled}
@@ -83,7 +85,7 @@ export default class GscapeNavigationMenu extends ContextualWidgetMixin(BaseMixi
                                   iri=${connectedClass.entityViewData.value.iri.fullIri}
                                   objpropertyiri=${objectProperty.entityViewData.value.iri.fullIri}
                                   direct=${objectProperty.direct}
-                                  type=${connectedClass.entityViewData.value.type}
+                                  .types=${connectedClass.entityViewData.value.types}
                                   ?actionable=${false}
                                 >
                                   <div slot="trailing-element" class="hover-btn">
@@ -133,7 +135,7 @@ export default class GscapeNavigationMenu extends ContextualWidgetMixin(BaseMixi
       const targetListItem = e.currentTarget as GscapeEntityListItem | null
 
       if (targetListItem &&
-        this.referenceEntity?.value.type === GrapholTypesEnum.CLASS_INSTANCE &&
+        this.referenceEntity?.value.types.has(GrapholTypesEnum.CLASS_INSTANCE) &&
         !targetListItem.disabled) {
         this.dispatchEvent(new CustomEvent('onobjectpropertyselection', {
           bubbles: true,

--- a/src/incremental/ui/node-buttons.ts/index.ts
+++ b/src/incremental/ui/node-buttons.ts/index.ts
@@ -58,21 +58,21 @@ export function NodeButtonsFactory(ic: IncrementalController) {
   })
 
   ic.on(IncrementalEvent.FocusStarted, instanceIri => {
-    const cyNode = ic.diagram.representation?.cy.$id(instanceIri)
+    const cyNode = ic.diagram.representation?.cy.$id(`${instanceIri}-${GrapholTypesEnum.CLASS_INSTANCE}`)
     if (cyNode) {
       addBadge(cyNode, textSpinner(), 'loading-badge')
     }
   })
 
   ic.on(IncrementalEvent.FocusFinished, instanceIri => {
-    const cyNode = ic.diagram.representation?.cy.$id(instanceIri)
+    const cyNode = ic.diagram.representation?.cy.$id(`${instanceIri}-${GrapholTypesEnum.CLASS_INSTANCE}`)
     if (cyNode && cyNode.scratch('loading-badge')) {
       removeBadge(cyNode, 'loading-badge')
     }
   })
 
   ic.on(IncrementalEvent.InstanceCheckingStarted, (instanceIri) => {
-    const cyNode = ic.diagram.representation?.cy.$id(instanceIri)
+    const cyNode = ic.diagram.representation?.cy.$id(`${instanceIri}-${GrapholTypesEnum.CLASS_INSTANCE}`)
     if (cyNode) {
       cyNode.addClass('unknown-parent-class')
       addBadge(cyNode, textSpinner(), 'loading-badge')
@@ -80,14 +80,14 @@ export function NodeButtonsFactory(ic: IncrementalController) {
   })
 
   ic.on(IncrementalEvent.InstanceCheckingFinished, (instanceIri) => {
-    const cyNode = ic.diagram.representation?.cy.$id(instanceIri)
+    const cyNode = ic.diagram.representation?.cy.$id(`${instanceIri}-${GrapholTypesEnum.CLASS_INSTANCE}`)
     if (cyNode && cyNode.scratch('loading-badge')) {
       removeBadge(cyNode, 'loading-badge')
     }
   })
 
   ic.on(IncrementalEvent.CountStarted, classIri => {
-    const node = ic.diagram.representation?.cy.$id(classIri)
+    const node = ic.diagram.representation?.cy.$id(`${classIri}-${GrapholTypesEnum.CLASS}`)
     if (!node || node.empty()) return
 
     removeBadge(node, 'instance-count')
@@ -95,7 +95,7 @@ export function NodeButtonsFactory(ic: IncrementalController) {
   })
 
   ic.on(IncrementalEvent.NewCountResult, (classIri, count) => {
-    const cyNode = ic.grapholscape.renderer.cy?.$id(classIri)
+    const cyNode = ic.grapholscape.renderer.cy?.$id(`${classIri}-${GrapholTypesEnum.CLASS}`)
     if (cyNode && cyNode.nonempty() && cyNode.scratch('instance-count')) {
       const instanceCountBadge = cyNode.scratch('instance-count') as NodeButton
       instanceCountBadge.contentType = 'template';

--- a/src/incremental/ui/node-buttons.ts/index.ts
+++ b/src/incremental/ui/node-buttons.ts/index.ts
@@ -183,6 +183,7 @@ async function handleObjectPropertyButtonClick(e: MouseEvent, incrementalControl
         return
 
       navigationMenu.referenceEntity = grapholEntityToEntityViewData(referenceEnity, incrementalController.grapholscape)
+      navigationMenu.referenceEntityType = targetButton.node.data().type
       navigationMenu.canShowObjectPropertiesRanges = true
 
 
@@ -195,6 +196,7 @@ async function handleObjectPropertyButtonClick(e: MouseEvent, incrementalControl
         return
 
       navigationMenu.referenceEntity = grapholEntityToEntityViewData(referenceEnity, incrementalController.grapholscape)
+      navigationMenu.referenceEntityType = targetButton.node.data().type
       navigationMenu.canShowObjectPropertiesRanges = false
 
       const parentClassesIris = (referenceEnity as ClassInstanceEntity).parentClassIris!.map(i => i.fullIri)
@@ -233,8 +235,8 @@ async function handleInstancesButtonClick(e: MouseEvent, incrementalController: 
 
   if (targetButton.node && targetButton.node.data().iri) {
     const referenceEntity = incrementalController.grapholscape.ontology.getEntity(targetButton.node.data().iri)
-
-    if (referenceEntity && referenceEntity.type === GrapholTypesEnum.CLASS) {
+    const entityType = targetButton.node.data().type
+    if (referenceEntity && entityType === GrapholTypesEnum.CLASS) {
       if (!instanceExplorer.referenceEntity ||
         !instanceExplorer.referenceEntity.value.iri.equals(referenceEntity.iri) ||
         instanceExplorer.numberOfInstancesReceived === 0) {
@@ -242,6 +244,7 @@ async function handleInstancesButtonClick(e: MouseEvent, incrementalController: 
 
         instanceExplorer.areInstancesLoading = true
         instanceExplorer.referenceEntity = grapholEntityToEntityViewData(referenceEntity, incrementalController.grapholscape)
+        instanceExplorer.referenceEntityType = targetButton.node.data().type
 
         const hasUnfoldings = incrementalController.endpointController?.highlightsManager?.hasUnfoldings.bind(
           incrementalController.endpointController?.highlightsManager

--- a/src/incremental/ui/on-hide-menu.ts
+++ b/src/incremental/ui/on-hide-menu.ts
@@ -5,11 +5,11 @@ import GscapeNavigationMenu from "./navigation-menu/navigation-menu";
 export default function(menu: GscapeNavigationMenu | GscapeInstanceExplorer, incrementalController: IncrementalController) {
     incrementalController.endpointController?.stopRequests('instances')
     
-    if (menu.referenceEntity) {
+    if (menu.referenceEntity && menu.referenceEntityType) {
       const refNode = incrementalController
         .diagram
         .representation
-        ?.cy.$id(menu.referenceEntity.value.iri.fullIri)
+        ?.cy.$id(`${menu.referenceEntity.value.iri.fullIri}-${menu.referenceEntityType}`)
 
       if (refNode?.scratch('should-unpin')) {
         refNode.removeScratch('should-unpin')

--- a/src/incremental/ui/show-menu.ts
+++ b/src/incremental/ui/show-menu.ts
@@ -6,11 +6,11 @@ import GscapeNavigationMenu from "./navigation-menu/navigation-menu";
 const panGraph = false
 
 export default function (menu: GscapeNavigationMenu | GscapeInstanceExplorer, incrementalController: IncrementalController) {
-  if (menu.referenceEntity) {
+  if (menu.referenceEntity && menu.referenceEntityType) {
     const cy = incrementalController.grapholscape.renderer.cy
 
     if (cy) {
-      const node = cy.$id(menu.referenceEntity.value.iri.fullIri)
+      const node = cy.$id(`${menu.referenceEntity.value.iri.fullIri}-${menu.referenceEntityType}`)
 
       if (node) {
         if (panGraph)

--- a/src/model/graph-structures/hierarchy.ts
+++ b/src/model/graph-structures/hierarchy.ts
@@ -1,7 +1,6 @@
 
 import { Position } from "cytoscape";
 import GrapholEdge from "../graphol-elems/edge";
-import GrapholEntity from "../graphol-elems/entity";
 import GrapholNode from "../graphol-elems/node";
 import { GrapholTypesEnum, Shape } from "../graphol-elems/enums";
 
@@ -56,7 +55,7 @@ export default class Hierarchy {
 
     this.inputs.forEach((inputClassIri, i) => {
       const newInputEdge = new GrapholEdge(`${this._id}-e-${i}`, GrapholTypesEnum.INPUT)
-      newInputEdge.sourceId = inputClassIri
+      newInputEdge.sourceId =  `${inputClassIri}-${GrapholTypesEnum.CLASS}`
       newInputEdge.targetId = this._id!
       res.push(newInputEdge)
     })
@@ -74,7 +73,7 @@ export default class Hierarchy {
     this._superclasses.forEach((superclass, i) => {
       const newInclusionEdge = new GrapholEdge(`${this._id}-inclusion-${i}`, this.type)
       newInclusionEdge.sourceId = this._id!
-      newInclusionEdge.targetId = superclass.classIri
+      newInclusionEdge.targetId = `${superclass.classIri}-${GrapholTypesEnum.CLASS}`
 
       if (superclass.complete) {
         newInclusionEdge.targetLabel = 'C'

--- a/src/model/graphol-elems/class-instance-entity.ts
+++ b/src/model/graphol-elems/class-instance-entity.ts
@@ -1,6 +1,5 @@
 import Iri from "../iri";
 import GrapholEntity from "./entity";
-import { GrapholTypesEnum } from "./enums";
 
 /** @internal */
 export default class ClassInstanceEntity extends GrapholEntity {
@@ -8,7 +7,7 @@ export default class ClassInstanceEntity extends GrapholEntity {
   private _parentClassIris: Iri[] = []
 
   constructor(iri: Iri, parentClassIris: Iri[] = []) {
-    super(iri, GrapholTypesEnum.CLASS_INSTANCE)
+    super(iri)
 
     this._parentClassIris = parentClassIris
   }

--- a/src/model/graphol-elems/enums.ts
+++ b/src/model/graphol-elems/enums.ts
@@ -59,7 +59,9 @@ export enum GrapholTypesEnum {
   /** @type {"membership"} */
   MEMBERSHIP = 'membership',
   /** @type {"class-instance"} */
-  CLASS_INSTANCE = 'class-instance'
+  CLASS_INSTANCE = 'class-instance',
+  /** @type {"unknown"} */
+  UNKWNOWN = 'unknown'
 }
 
 /**

--- a/src/model/graphol-elems/graphol-element.ts
+++ b/src/model/graphol-elems/graphol-element.ts
@@ -1,6 +1,6 @@
 import { ElementDefinition } from "cytoscape"
-import { GrapholTypesEnum } from "./enums"
 import GrapholEntity, { FunctionalityEnum } from "./entity"
+import { GrapholTypesEnum } from "./enums"
 
 export default class GrapholElement {
   // The id coming from xml
@@ -9,6 +9,7 @@ export default class GrapholElement {
   private _displayedName?: string
   private _originalId?: string // In case of replicated elements, this is the id of the original node
   private _iri?: string
+  private _diagramId: number
 
   constructor(private _id: string, private _type: GrapholTypesEnum) { }
 
@@ -32,6 +33,11 @@ export default class GrapholElement {
 
   get iri() { return this._iri }
   set iri(iri: string | undefined) { this._iri = iri }
+
+  get diagramId() { return this._diagramId }
+  set diagramId(newdiagramId) {
+    this._diagramId = newdiagramId
+  }
 
   /**
    * Check if node is of a certain type

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -71,11 +71,11 @@ export default class GrapholParser {
             grapholEntity = this.ontology.entities.get(iri.fullIri)
 
             if (!grapholEntity) {
-              grapholEntity = new GrapholEntity(iri, grapholNodeType)
+              grapholEntity = new GrapholEntity(iri)
               this.ontology.addEntity(grapholEntity)
             }
 
-            grapholEntity.addOccurrence(node.id, diagram.id)
+            grapholEntity.addOccurrence(node)
             grapholEntity.functionalities = this.graphol.getFunctionalities(nodeXmlElement, this.xmlDocument)
             grapholEntity.annotations = this.graphol.getEntityAnnotations(nodeXmlElement, this.xmlDocument)
 
@@ -148,6 +148,7 @@ export default class GrapholParser {
       return
     }
     let grapholNode = new GrapholNode(element.getAttribute('id') || '', nodeInfoBasedOnType.TYPE)
+    grapholNode.diagramId = diagramId
     grapholNode.shape = nodeInfoBasedOnType.SHAPE
     grapholNode.identity = nodeInfoBasedOnType.IDENTITY
     grapholNode.fillColor = element.getAttribute('color') || ''

--- a/src/ui/common/annotations-template.ts
+++ b/src/ui/common/annotations-template.ts
@@ -4,7 +4,7 @@ import { annotationIcons, entityIcons } from '../assets/icons'
 
 export type ViewItemWithIri = {
   name: string,
-  typeOrVersion: string,
+  typeOrVersion: Set<string>,
   iri: string
 }
 
@@ -25,9 +25,18 @@ export function itemWithIriTemplate(item: ViewItemWithIri, onWikiLinkClick?: (ir
       </div>
       <div class="muted-text" title="iri: ${item.iri}"><bdo dir="ltr">${item.iri}</bdo></div>
       <div class="muted-text type-or-version">
-        ${Object.values(GrapholTypesEnum).includes(item.typeOrVersion as GrapholTypesEnum)
-          ? entityIcons[item.typeOrVersion] : null }
-        ${item.typeOrVersion || '-'}
+        ${item.typeOrVersion.forEach(text => {
+          if (Object.values(GrapholTypesEnum).includes(text as GrapholTypesEnum)) {
+            return html`
+              <div>
+                ${entityIcons[text]}
+                ${item.typeOrVersion || '-'}
+              </div>
+            `
+          } else {
+            return item.typeOrVersion || '-'
+          }
+        })}
       </div>
     </div>
   `

--- a/src/ui/common/annotations-template.ts
+++ b/src/ui/common/annotations-template.ts
@@ -15,7 +15,7 @@ export function itemWithIriTemplate(item: ViewItemWithIri, onWikiLinkClick?: (ir
   }
 
   return html`
-    <div class="item-with-iri-info ellipsed rtl">
+    <div class="item-with-iri-info ellipsed">
       <div 
         class="name ${onWikiLinkClick ? 'link' : null}" 
         title="${item.name}"
@@ -23,18 +23,18 @@ export function itemWithIriTemplate(item: ViewItemWithIri, onWikiLinkClick?: (ir
       >
         ${item.name}
       </div>
-      <div class="muted-text" title="iri: ${item.iri}"><bdo dir="ltr">${item.iri}</bdo></div>
+      <div class="rtl"><div class="muted-text" style="text-align: center" title="iri: ${item.iri}"><bdo dir="ltr">${item.iri}</bdo></div></div>
       <div class="muted-text type-or-version">
-        ${item.typeOrVersion.forEach(text => {
+        ${Array.from(item.typeOrVersion).map(text => {
           if (Object.values(GrapholTypesEnum).includes(text as GrapholTypesEnum)) {
             return html`
-              <div>
+              <div class="type-or-version">
                 ${entityIcons[text]}
-                ${item.typeOrVersion || '-'}
+                ${text || '-'}
               </div>
             `
           } else {
-            return item.typeOrVersion || '-'
+            return text || '-'
           }
         })}
       </div>
@@ -49,7 +49,7 @@ export const itemWithIriTemplateStyle = css`
     white-space: nowrap;
   }
 
-  .item-with-iri-info > .type-or-version {
+  .item-with-iri-info .type-or-version {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/ui/common/imgs-horizontal-list.ts
+++ b/src/ui/common/imgs-horizontal-list.ts
@@ -1,0 +1,60 @@
+import { LitElement, SVGTemplateResult, css, html } from "lit";
+import baseStyle from "../style";
+
+export default class GscapeIconList extends LitElement {
+
+  icons: SVGTemplateResult[] = []
+
+  static properties = {
+    icons: { type: Array }
+  }
+
+  static styles = [
+    baseStyle,
+    css`
+    :host {
+      display: inline-block;
+    }
+
+    .icons {
+      display: flex;
+    }
+
+    .icon-item:first-of-type {
+      margin-left: 0;
+      padding-left: 0;
+    }
+    
+    .icon-item {
+      /* Nagative margin make icons overlap to previous one */
+      margin-left: -0.5rem;
+      border-radius: 9999px;
+      background: inherit;
+      padding-left: 2px;
+    }
+    
+    .icon-img {
+      justify-content: center;
+      align-items: center;
+      display: flex;
+      background: inherit;
+    }
+    `
+  ]
+
+  render() {
+    return html`
+      <div class="icons background-propagation">
+        ${this.icons.map(i => {
+          return html`
+            <div class="icon-item">
+              <div class="icon-img slotted-icon">${i}
+            </div>
+          `
+        })}
+      </div>
+    `
+  }
+}
+
+customElements.define('gscape-icon-list', GscapeIconList)

--- a/src/ui/common/list-item/entity-list-item.ts
+++ b/src/ui/common/list-item/entity-list-item.ts
@@ -1,17 +1,14 @@
 import { css, CSSResultGroup, html, LitElement, PropertyDeclarations } from "lit";
 import baseStyle from "../../style";
-import { GrapholTypesEnum } from "../../../model";
 import { arrowDown, arrow_right, entityIcons } from "../../assets";
 import entityListItemStyle from "./entity-list-item-style";
+import GscapeIconList from "../imgs-horizontal-list";
+
+GscapeIconList
 
 export default class GscapeEntityListItem extends LitElement {
 
-  type: GrapholTypesEnum.CLASS |
-    GrapholTypesEnum.DATA_PROPERTY |
-    GrapholTypesEnum.OBJECT_PROPERTY |
-    GrapholTypesEnum.INDIVIDUAL |
-    GrapholTypesEnum.CLASS_INSTANCE
-    = GrapholTypesEnum.CLASS
+  types: Set<string> = new Set()
 
   displayedName: string = ''
   iri: string = ''
@@ -21,7 +18,7 @@ export default class GscapeEntityListItem extends LitElement {
   private isAccordionOpen = false
 
   static properties: PropertyDeclarations = {
-    type: { type: String, reflect: true },
+    types: { type: Object, reflect: true },
     displayedName: { type: String, reflect: true },
     actionable: { type: Boolean },
     asAccordion: { type: Boolean },
@@ -52,7 +49,7 @@ export default class GscapeEntityListItem extends LitElement {
         </details>
       `
       : html`
-        <div title=${this.displayedName} class="ellipsed entity-list-item ${this.actionable ? 'actionable' : null}" ?disabled=${this.disabled}>
+        <div title=${this.displayedName} class="ellipsed background-propagation entity-list-item ${this.actionable ? 'actionable' : null}" ?disabled=${this.disabled}>
           ${this.iconNameSlotTemplate()}
         </div>
       `
@@ -71,7 +68,9 @@ export default class GscapeEntityListItem extends LitElement {
         `
         : null
       }      
-      <span class="entity-icon slotted-icon">${entityIcons[this.type]}</span>
+      <span class="entity-icon slotted-icon">
+        <gscape-icon-list .icons=${Array.from(this.types).map(t => entityIcons[t])}></gscape-icon-list>
+      </span>
       <div style="display: flex; flex-direction: column; flex-grow: 2; gap: 4px">
         <span class="entity-name rtl"><bdo dir="ltr">${this.displayedName}</bdo></span>
         <slot name="subrow-item"></slot>

--- a/src/ui/common/list-item/entity-list-item.ts
+++ b/src/ui/common/list-item/entity-list-item.ts
@@ -8,7 +8,7 @@ GscapeIconList
 
 export default class GscapeEntityListItem extends LitElement {
 
-  types: Set<string> = new Set()
+  private _types: Set<string> = new Set()
 
   displayedName: string = ''
   iri: string = ''
@@ -69,7 +69,7 @@ export default class GscapeEntityListItem extends LitElement {
         : null
       }      
       <span class="entity-icon slotted-icon">
-        <gscape-icon-list .icons=${Array.from(this.types).map(t => entityIcons[t])}></gscape-icon-list>
+        <gscape-icon-list .icons=${Array.from(this._types).map(t => entityIcons[t])}></gscape-icon-list>
       </span>
       <div style="display: flex; flex-direction: column; flex-grow: 2; gap: 4px">
         <span class="entity-name rtl"><bdo dir="ltr">${this.displayedName}</bdo></span>
@@ -93,6 +93,14 @@ export default class GscapeEntityListItem extends LitElement {
   closeAccordion() {
     if (this.asAccordion)
       this.isAccordionOpen = false
+  }
+
+  set types(newTypes: Set<string> | undefined) {
+    this._types = newTypes || new Set()
+  }
+
+  get types() {
+    return this._types
   }
 }
 

--- a/src/ui/common/mixins/drop-panel-mixin.ts
+++ b/src/ui/common/mixins/drop-panel-mixin.ts
@@ -5,6 +5,7 @@ import { LitElement } from "lit";
 type Constructor<T = {}> = new (...args: any[]) => T;
 
 export declare class IDropPanelMixin {
+  protected isDefaultClosed: boolean
   togglePanel(): void
   openPanel(): void
   closePanel(): void
@@ -19,6 +20,7 @@ export const DropPanelMixin = <T extends Constructor<LitElement>>(superClass: T)
   class DropPanelMixinClass extends superClass {
 
     protected get panel(): HTMLElement | undefined | null { return this.shadowRoot?.querySelector('#drop-panel') }
+    protected isDefaultClosed = true
 
     togglePanel() {
       this.isPanelClosed() ? this.openPanel() : this.closePanel()
@@ -62,7 +64,11 @@ export const DropPanelMixin = <T extends Constructor<LitElement>>(superClass: T)
     }
 
     isPanelClosed() {
-      return this.panel ? this.panel.classList.contains('hide') : true // default closed
+      if (this.panel) {
+        return this.panel.classList.contains('hide')
+      } else {
+        return this.isDefaultClosed
+      }
     }
 
     onTogglePanel = () => {}

--- a/src/ui/entity-details/controller.ts
+++ b/src/ui/entity-details/controller.ts
@@ -1,5 +1,5 @@
 import Grapholscape from '../../core'
-import { GrapholEntity, LifecycleEvent, RendererStatesEnum } from '../../model'
+import { GrapholElement, GrapholEntity, LifecycleEvent, RendererStatesEnum } from '../../model'
 import getEntityViewOccurrences from '../util/get-entity-view-occurrences'
 import GscapeEntityDetails from './entity-details'
 
@@ -37,8 +37,11 @@ export default function (entityDetailsComponent: GscapeEntityDetails, grapholsca
   })
 
 
-  function setGrapholEntity(entity: GrapholEntity) {
+  function setGrapholEntity(entity: GrapholEntity, instance?: GrapholElement) {
     entityDetailsComponent.grapholEntity = entity
+    if (instance) {
+      entityDetailsComponent.currentOccurrenceType = instance.type
+    }
     entityDetailsComponent.occurrences = getEntityViewOccurrences(entity, grapholscape)
     entityDetailsComponent.language = grapholscape.language
     entityDetailsComponent.show()

--- a/src/ui/entity-details/controller.ts
+++ b/src/ui/entity-details/controller.ts
@@ -5,9 +5,9 @@ import GscapeEntityDetails from './entity-details'
 
 export default function (entityDetailsComponent: GscapeEntityDetails, grapholscape: Grapholscape) {
   // entityDetailsComponent.onWikiClick = (iri) => grapholscape.wikiRedirectTo(iri)
-  entityDetailsComponent.onNodeNavigation = (entityOccurrence) => {
-    grapholscape.centerOnElement(entityOccurrence.elementId, entityOccurrence.diagramId, 1.2)
-    grapholscape.selectElement(entityOccurrence.elementId)
+  entityDetailsComponent.onNodeNavigation = (elementId, diagramId) => {
+    grapholscape.centerOnElement(elementId, diagramId, 1.2)
+    grapholscape.selectElement(elementId)
   }
   entityDetailsComponent.language = grapholscape.language
 

--- a/src/ui/entity-details/entity-details.ts
+++ b/src/ui/entity-details/entity-details.ts
@@ -18,6 +18,8 @@ export default class GscapeEntityDetails extends DropPanelMixin(BaseMixin(LitEle
 
   incrementalSection?: HTMLElement
 
+  protected isDefaultClosed: boolean = false
+
   static get properties() {
     return {
       grapholEntity: { type: Object, attribute: false },

--- a/src/ui/entity-details/entity-details.ts
+++ b/src/ui/entity-details/entity-details.ts
@@ -1,5 +1,5 @@
-import { css, html, LitElement } from 'lit'
-import { GrapholEntity, GrapholTypesEnum } from '../../model'
+import { css, html, LitElement, PropertyValueMap } from 'lit'
+import { GrapholElement, GrapholEntity, GrapholTypesEnum } from '../../model'
 import { commentIcon, infoFilled, minus, plus } from '../assets/icons'
 import { annotationsStyle, annotationsTemplate, itemWithIriTemplate, itemWithIriTemplateStyle, ViewItemWithIri } from '../common/annotations-template'
 import { BaseMixin, DropPanelMixin } from '../common/mixins'
@@ -10,6 +10,7 @@ import { DiagramViewData, getEntityOccurrencesTemplate, OccurrenceIdViewData } f
 export default class GscapeEntityDetails extends DropPanelMixin(BaseMixin(LitElement)) {
   title = 'Entity Details'
   grapholEntity: GrapholEntity
+  currentOccurrenceType?: GrapholTypesEnum
   occurrences: Map<DiagramViewData, OccurrenceIdViewData[]>
   showOccurrences: boolean = true
   language: string
@@ -123,7 +124,7 @@ export default class GscapeEntityDetails extends DropPanelMixin(BaseMixin(LitEle
     if (!this.grapholEntity) return
     return html`
       <div class="gscape-panel ellipsed" id="drop-panel">
-        ${!this.grapholEntity.is(GrapholTypesEnum.CLASS_INSTANCE)
+        ${this.currentOccurrenceType !== GrapholTypesEnum.CLASS_INSTANCE
             ? itemWithIriTemplate(this.entityForTemplate, this.onWikiLinkClick)
             : itemWithIriTemplate(this.entityForTemplate)
         }
@@ -219,7 +220,7 @@ export default class GscapeEntityDetails extends DropPanelMixin(BaseMixin(LitEle
   // override blur to avoid collapsing when clicking on cytoscape's canvas
   blur() { }
 
-  setGrapholEntity(entity: GrapholEntity) { }
+  setGrapholEntity(entity: GrapholEntity, instance?: GrapholElement) { }
 
   private languageSelectionHandler(e) {
     this.language = e.target.value
@@ -228,7 +229,7 @@ export default class GscapeEntityDetails extends DropPanelMixin(BaseMixin(LitEle
   private get entityForTemplate() {
     const result: ViewItemWithIri = {
       name: this.grapholEntity.iri.remainder,
-      typeOrVersion: this.grapholEntity.types,
+      typeOrVersion: this.currentOccurrenceType ? new Set([this.currentOccurrenceType]) : this.grapholEntity.types,
       iri: this.grapholEntity.iri.fullIri,
     }
     return result

--- a/src/ui/entity-details/entity-details.ts
+++ b/src/ui/entity-details/entity-details.ts
@@ -1,6 +1,5 @@
 import { css, html, LitElement } from 'lit'
 import { GrapholEntity, GrapholTypesEnum } from '../../model'
-import { EntityOccurrence } from '../../model/graphol-elems/entity'
 import { commentIcon, infoFilled, minus, plus } from '../assets/icons'
 import { annotationsStyle, annotationsTemplate, itemWithIriTemplate, itemWithIriTemplateStyle, ViewItemWithIri } from '../common/annotations-template'
 import { BaseMixin, DropPanelMixin } from '../common/mixins'
@@ -14,7 +13,7 @@ export default class GscapeEntityDetails extends DropPanelMixin(BaseMixin(LitEle
   occurrences: Map<DiagramViewData, OccurrenceIdViewData[]>
   showOccurrences: boolean = true
   language: string
-  onNodeNavigation: (occurrence: EntityOccurrence) => void = () => { }
+  onNodeNavigation: (elmentId: string, diagramId: number) => void = () => { }
   onWikiLinkClick: (iri: string) => void
 
   incrementalSection?: HTMLElement
@@ -227,7 +226,7 @@ export default class GscapeEntityDetails extends DropPanelMixin(BaseMixin(LitEle
   private get entityForTemplate() {
     const result: ViewItemWithIri = {
       name: this.grapholEntity.iri.remainder,
-      typeOrVersion: this.grapholEntity.type.toString(),
+      typeOrVersion: this.grapholEntity.types,
       iri: this.grapholEntity.iri.fullIri,
     }
     return result

--- a/src/ui/entity-selector/entity-selector.ts
+++ b/src/ui/entity-selector/entity-selector.ts
@@ -125,7 +125,6 @@ export class GscapeEntitySelector extends DropPanelMixin(BaseMixin(LitElement)) 
   }
 
   render() {
-    console.log(this.entityList)
     return html`
       <div class="gscape-panel widget-body">
         <div id="input-wrapper">

--- a/src/ui/entity-selector/entity-selector.ts
+++ b/src/ui/entity-selector/entity-selector.ts
@@ -125,6 +125,7 @@ export class GscapeEntitySelector extends DropPanelMixin(BaseMixin(LitElement)) 
   }
 
   render() {
+    console.log(this.entityList)
     return html`
       <div class="gscape-panel widget-body">
         <div id="input-wrapper">
@@ -156,12 +157,13 @@ export class GscapeEntitySelector extends DropPanelMixin(BaseMixin(LitElement)) 
             ? html`
               <lit-virtualizer
                 scroller
+                class="background-propagation"
                 style="min-height: 100%;"
                 .items=${this.entityList}
                 .renderItem=${(entityItem: EntityViewData) => html`
                   <gscape-entity-list-item
                     style="width:100%"
-                    type=${entityItem.value.type}
+                    .types=${entityItem.value.types}
                     displayedName=${entityItem.displayedName}
                     title=${entityItem.displayedName}
                     iri=${entityItem.value.iri.fullIri}

--- a/src/ui/ontology-explorer/controller.ts
+++ b/src/ui/ontology-explorer/controller.ts
@@ -6,9 +6,9 @@ import { IEntityFilters } from '../view-model';
 import GscapeExplorer from "./ontology-explorer";
 
 export default function (ontologyExplorerComponent: GscapeExplorer, grapholscape: Grapholscape) {
-  ontologyExplorerComponent.onNodeNavigation = (entityOccurrence) => {
-    grapholscape.centerOnElement(entityOccurrence.elementId, entityOccurrence.diagramId, 1.2)
-    grapholscape.selectElement(entityOccurrence.elementId)
+  ontologyExplorerComponent.onNodeNavigation = (elementId, diagramId) => {
+    grapholscape.centerOnElement(elementId, diagramId, 1.2)
+    grapholscape.selectElement(elementId)
   }
 
   ontologyExplorerComponent.addEventListener('onentityfilterchange', (e: EntityFilterEvent) => {

--- a/src/ui/ontology-explorer/ontology-explorer.ts
+++ b/src/ui/ontology-explorer/ontology-explorer.ts
@@ -1,5 +1,4 @@
 import { css, html, LitElement } from 'lit'
-import { EntityOccurrence } from '../../model/graphol-elems/entity'
 import { blankSlateDiagrams, explore } from '../assets/icons'
 import { BaseMixin, DropPanelMixin } from '../common/mixins'
 import { GscapeEntitySearch } from '../common/text-search'
@@ -21,7 +20,7 @@ export default class GscapeExplorer extends DropPanelMixin(BaseMixin(LitElement)
   loading = false
   // search: (e:any) => void = () => { }
   // filterEntities: (entityFilters: IEntityFilters) => void = () => { }
-  onNodeNavigation: (occurrence: EntityOccurrence) => void = () => { }
+  onNodeNavigation: (elementId: string, diagramId: number) => void = () => { }
   // onSearch: (e: KeyboardEvent) => void
   // onEntityFilterToggle: () => void
 
@@ -117,6 +116,7 @@ export default class GscapeExplorer extends DropPanelMixin(BaseMixin(LitElement)
                 <div style="padding: 0 8px; height: inherit">
                   <lit-virtualizer
                     scroller
+                    class="background-propagation"
                     style="min-height: 100%"
                     .items=${this.shownEntities}
                     .renderItem=${(entity: EntityViewData) => html`
@@ -124,7 +124,7 @@ export default class GscapeExplorer extends DropPanelMixin(BaseMixin(LitElement)
                         style="width: 100%"
                         ?asaccordion=${true}
                         displayedname=${entity.displayedName}
-                        type=${entity.value.type}
+                        .types=${entity.value.types}
                         iri=${entity.value.iri.fullIri}
                       >
                         <div slot="accordion-body">

--- a/src/ui/ontology-info/index.ts
+++ b/src/ui/ontology-info/index.ts
@@ -16,7 +16,7 @@ export default function initOntologyInfo(grapholscape) {
 function ontologyModelToViewData(ontologyModelData: Ontology) {
   let ontologyViewData: OntologyViewModel = {
     name: ontologyModelData.name,
-    typeOrVersion: new Set(ontologyModelData.version),
+    typeOrVersion: new Set([ontologyModelData.version]),
     iri: ontologyModelData.iri || '',
     namespaces: ontologyModelData.namespaces,
     annotations: ontologyModelData.annotations,

--- a/src/ui/ontology-info/index.ts
+++ b/src/ui/ontology-info/index.ts
@@ -16,7 +16,7 @@ export default function initOntologyInfo(grapholscape) {
 function ontologyModelToViewData(ontologyModelData: Ontology) {
   let ontologyViewData: OntologyViewModel = {
     name: ontologyModelData.name,
-    typeOrVersion: ontologyModelData.version,
+    typeOrVersion: new Set(ontologyModelData.version),
     iri: ontologyModelData.iri || '',
     namespaces: ontologyModelData.namespaces,
     annotations: ontologyModelData.annotations,

--- a/src/ui/owl-visualizer/owl-visualizer.ts
+++ b/src/ui/owl-visualizer/owl-visualizer.ts
@@ -7,6 +7,8 @@ export default class GscapeOwlVisualizer extends BaseMixin(DropPanelMixin(LitEle
   title = "OWL 2 Translation"
   owlText: string = ''
 
+  protected isDefaultClosed: boolean = false
+
   static properties = {
     owlText: { type: String, attribute: false }
   }

--- a/src/ui/style.ts
+++ b/src/ui/style.ts
@@ -20,6 +20,10 @@ export default css`
   border-color: var(--gscape-color-border-default);
 }
 
+.background-propagation, .background-propagation * {
+  background: inherit;
+}
+
 .gscape-panel {
   font-size: 12px;
   background-color: var(--gscape-color-bg-default);

--- a/src/ui/util/search-entities.ts
+++ b/src/ui/util/search-entities.ts
@@ -48,7 +48,12 @@ export function createEntitiesList(grapholscape: Grapholscape, entityFilters?: I
 function shouldFilterEntity(entity: GrapholEntity, entityFilters?: IEntityFilters) {
   if (!entityFilters) return false
 
-  return !entityFilters.areAllFiltersDisabled && entityFilters[entity.type] !== 1 && entityFilters[entity.type] !== true
+  let typeFilterEnabled = true
+  entity.types.forEach(type => {
+    typeFilterEnabled = typeFilterEnabled && entityFilters[type] !== 1 && entityFilters[type] !== true
+  })
+
+  return !entityFilters.areAllFiltersDisabled && typeFilterEnabled
 }
 
 export function search(searchValue: string, entities: EntityViewData[]) {

--- a/src/ui/view-model.ts
+++ b/src/ui/view-model.ts
@@ -15,7 +15,7 @@ export type EntityViewDataUnfolding = {
 
 export type EntityViewData = {
   displayedName: string,
-  value: { iri: Iri, type: GrapholTypesEnum } & AnnotatedElement, // GrapholEntity is a compatible type
+  value: { iri: Iri, types: Set<GrapholTypesEnum> } & AnnotatedElement, // GrapholEntity is a compatible type
   viewOccurrences?: Map<DiagramViewData, OccurrenceIdViewData[]>
 }
 

--- a/src/util/graphol-entity-to-entity-view-data.ts
+++ b/src/util/graphol-entity-to-entity-view-data.ts
@@ -11,8 +11,19 @@ export function grapholEntityToEntityViewData(grapholEntity: GrapholEntity, grap
 }
 
 export function getEntityViewDataUnfolding(entity: GrapholEntity, grapholscape: Grapholscape, hasUnfoldings?: (iri: string, type: GrapholTypesEnum) => boolean ) {
+  let hasAnyUnfolding = true
+
+  if (hasUnfoldings) {
+    entity.types.forEach(type => {
+      hasAnyUnfolding = hasAnyUnfolding && hasUnfoldings(entity.iri.fullIri, type)
+    })
+  } else {
+    hasAnyUnfolding = false
+  }
+  
+
   return {
     entityViewData: grapholEntityToEntityViewData(entity, grapholscape),
-    hasUnfolding: hasUnfoldings && hasUnfoldings(entity.iri.fullIri, entity.type)
+    hasUnfolding:hasAnyUnfolding
   } as EntityViewDataUnfolding
 }

--- a/test/parser-v3.test.ts
+++ b/test/parser-v3.test.ts
@@ -187,7 +187,7 @@ describe('Test retrieving annotations', () => {
   `)
 
   const retrievedInfosConcept = parserV3.getEntityAnnotations(node1_mock_input, xmlDoc)
-  const conceptEntity = new GrapholEntity(new Iri('http://www.obdasystems.com/testNode1', ontology.namespaces), GrapholTypesEnum.CLASS)
+  const conceptEntity = new GrapholEntity(new Iri('http://www.obdasystems.com/testNode1', ontology.namespaces))
   conceptEntity.annotations = retrievedInfosConcept
 
   test('it should parse multiple labels for each language, even not defined language', () => {
@@ -230,7 +230,7 @@ describe('Test parsing functionalities', () => {
   `)
 
   const retrievedInfosObjectProperty = parserV3.getFunctionalities(node_mock_input, xmlDoc)
-  const objPropertyEntity = new GrapholEntity(new Iri('http://www.obdasystems.com/testNode2', ontology.namespaces), GrapholTypesEnum.OBJECT_PROPERTY)
+  const objPropertyEntity = new GrapholEntity(new Iri('http://www.obdasystems.com/testNode2', ontology.namespaces))
   objPropertyEntity.functionalities = retrievedInfosObjectProperty
 
   // For DataProperties and ObjectProperties


### PR DESCRIPTION
PR per aggiornare il branch develop e usare i tipi multipli sulle entità.

Principali cambiamenti impattanti
 - Le [`GrapholEntity`](https://github.com/obdasystems/grapholscape/blob/refactor-entities-types/src/model/graphol-elems/entity.ts) non hanno più il campo `type` ma un getter [`types`](https://github.com/obdasystems/grapholscape/blob/fcc115b5ebb6124563fb2fce61b226129b9d1d9a/src/model/graphol-elems/entity.ts#L87C16-L87C16)che restituisce un Set di `GrapholTypesEnum` di tutte le occorrenze dell'entità.
 - Il campo [`occurrences`](https://github.com/obdasystems/grapholscape/blob/fcc115b5ebb6124563fb2fce61b226129b9d1d9a/src/model/graphol-elems/entity.ts#L20) sulle [`GrapholEntity`](https://github.com/obdasystems/grapholscape/blob/refactor-entities-types/src/model/graphol-elems/entity.ts) adesso è una mappa per renderer state di array di [`GrapholElement`](https://github.com/obdasystems/grapholscape/blob/refactor-entities-types/src/model/graphol-elems/graphol-element.ts), gli stessi che si trovano nelle varie [`DiagramRepresentation`](https://github.com/obdasystems/grapholscape/blob/refactor-entities-types/src/model/diagrams/diagram-representation.ts).
 - Ne consegue che l'IRI di un'entità rappresentata da un nodo (non object properties) non è più sufficiente per identificarne univocamente il nodo in cytoscape. La convenzione per gli ID delle classi e le istanze di classi che ho usato per l'incremental (quindi nel VKG)  è: [IRI]-[TIPO].